### PR TITLE
POST /files endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "edge-currency-bitcoin": "^4.7.7",
     "express": "^4.17.1",
     "express-promise-router": "^4.0.1",
-    "nano": "^8.2.2",
+    "nano": "^9.0.1",
     "react-bootstrap": "^1.0.0-beta.16"
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,9 @@
 import nano from 'nano'
 import config from '../config.json'
+import { StoreDirectory, StoreFile, StoreRoot } from './types'
 
 const url = `http://admin:${config.couchAdminPassword}@${config.couchHost}:${config.couchPort}`
 
-export const dataStore = nano(url).use('datastore')
+type AllDocumentTypes = StoreRoot | StoreDirectory | StoreFile
+
+export const dataStore = nano(url).use<AllDocumentTypes>('datastore')

--- a/src/db.ts
+++ b/src/db.ts
@@ -6,4 +6,4 @@ const url = `http://admin:${config.couchAdminPassword}@${config.couchHost}:${con
 
 type AllDocumentTypes = StoreRoot | StoreDirectory | StoreFile
 
-export const dataStore = nano(url).use<AllDocumentTypes>('datastore')
+export const dataStore = nano(url).use<AllDocumentTypes>('sync_datastore')

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -1,13 +1,364 @@
+import { asEither, asMap, asNull, asNumber, asObject, asString } from 'cleaners'
 import Router from 'express-promise-router'
+import { DocumentBulkResponse } from 'nano'
+
 import { dataStore } from '../db'
 import {
   ApiErrorResponse,
   ApiResponse,
+  asStoreDirectoryDocument,
+  asStoreFile,
+  asStoreFileDocument,
+  asStoreRootDocument,
   DocumentRequest,
-  Results
+  Results,
+  StoreDirectory,
+  StoreDirectoryDocument,
+  StoreFile,
+  StoreFileDocument,
+  StoreRootDocument
 } from '../types'
+import {
+  getNameFromPath,
+  getParentPathsOfPath,
+  makeApiClientError,
+  mergeDirectoryFilePointers,
+  updateDirectoryFilePointers
+} from '../utils'
+
+type FilesPostBody = ReturnType<typeof asFilesPostBody>
+const asFilesPostBody = asObject({
+  timestamp: asNumber,
+  repoId: asString,
+  paths: asMap(asEither(asStoreFile, asNull))
+})
+
+interface FilesPostResponseData {
+  timestamp: number
+  paths: {
+    [path: string]: number
+  }
+}
+
+const VALID_PATH_REGEX = /^(\/([^/ ]+([ ]+[^/ ]+)*)+)+\/?$/
 
 export const filesRouter = Router()
+
+// ---------------------------------------------------------------------
+// POST /files
+// ---------------------------------------------------------------------
+
+filesRouter.post('/files', async (req, res) => {
+  let body: FilesPostBody
+  let paths: string[]
+  let fileKeys: string[]
+  let repoId: string
+  let repoKey: string
+
+  // Validate request body
+  try {
+    body = asFilesPostBody(req.body)
+    repoId = body.repoId
+    repoKey = `${repoId}:/`
+
+    if (repoId === '') {
+      throw new Error(`Missing repoId.`)
+    }
+
+    paths = Object.keys(body.paths)
+
+    // Validate paths are formated correctly
+    paths.forEach(path => {
+      if (path === '/') {
+        throw new Error(`Invalid path '${path}'. Path cannot be root.`)
+      }
+      if (!VALID_PATH_REGEX.test(path)) {
+        throw new Error(`Invalid path '${path}'`)
+      }
+    })
+
+    fileKeys = paths.map(path => `${repoId}:${path}`)
+  } catch (error) {
+    throw makeApiClientError(400, error.message)
+  }
+
+  // Validate request body timestamp
+  let repoDoc: StoreRootDocument
+  try {
+    const repoQuery = await dataStore.get(repoKey)
+    repoDoc = asStoreRootDocument(repoQuery)
+  } catch (err) {
+    throw new Error(`Failed to validate repo: ${err.message}`)
+  }
+
+  if (repoDoc.timestamp !== body.timestamp) {
+    throw makeApiClientError(422, `Failed due to out-of-date timestamp`)
+  }
+
+  // Timestamp is the same for all updates for this request
+  let requestTimestamp = Date.now()
+  let retries: number = 0
+
+  while (true) {
+    try {
+      if (retries < 100) {
+        await filesUpdateRoutine(body, repoKey, fileKeys, requestTimestamp)
+      } else {
+        throw new Error(`Failed to resolve conflicts after ${retries} attempts`)
+      }
+    } catch (err) {
+      if (err.message === 'conflict') {
+        requestTimestamp = Date.now()
+        retries += 1
+        continue
+      } else {
+        throw err
+      }
+    }
+
+    break
+  }
+
+  // Response:
+
+  const responseData: FilesPostResponseData = {
+    timestamp: requestTimestamp,
+    paths: paths.reduce((paths, path) => {
+      paths[path] = requestTimestamp
+      return paths
+    }, {})
+  }
+
+  const response: ApiResponse<FilesPostResponseData> = {
+    success: true,
+    data: responseData
+  }
+  res.status(200).json(response)
+})
+
+const filesUpdateRoutine = async (
+  body: FilesPostBody,
+  repoKey: string,
+  fileKeys: string[],
+  requestTimestamp: number
+): Promise<void> => {
+  // Prepare Files Documents:
+
+  const fileRevsResult = await dataStore.fetch({ keys: fileKeys })
+  const storeFileDocuments: StoreFileDocument[] = []
+  const directoryModifications: Map<string, StoreDirectory> = new Map()
+  let repoModification: Pick<
+    StoreRootDocument,
+    'paths' | 'deleted' | 'timestamp'
+  > = { paths: {}, deleted: {}, timestamp: 0 }
+
+  // Prepare file documents:
+  fileRevsResult.rows.forEach(row => {
+    const fileKey = row.key
+    const [repoId, filePath] = fileKey.split(':')
+    const storeFile: StoreFile = body.paths[filePath] ?? { text: '' }
+    const isDeletion = body.paths[filePath] === null
+
+    if (!isDeletion) {
+      if ('doc' in row) {
+        try {
+          asStoreFileDocument(row.doc)
+        } catch (err) {
+          throw makeApiClientError(
+            422,
+            `Unable to write file '${fileKey}'. ` +
+              `Existing document is not a file.`
+          )
+        }
+
+        // Document will be overwritten
+        storeFileDocuments.push({
+          ...storeFile,
+          _id: fileKey,
+          _rev: row.value.rev
+        })
+      } else {
+        // Document will be inserted
+        storeFileDocuments.push({ ...storeFile, _id: fileKey })
+      }
+    }
+
+    // Directories and Repo Modifications:
+
+    // Prepare Directory Modificaitons:
+
+    const directoryPaths = getParentPathsOfPath(filePath)
+    const fileName = getNameFromPath(filePath)
+
+    directoryPaths.forEach((directoryPath, index) => {
+      // Get the existing directory modification object
+      const directoryKey = `${repoId}:${directoryPath}`
+      const existingDirModification = directoryModifications.get(directoryKey)
+
+      // If this directory isn't the immediate parent directory of the file,
+      // then we want to use the child directory for this directory as the
+      // file pointer path.
+      const childDirectoryPath = directoryPaths[index - 1]
+      const filePointerPath =
+        childDirectoryPath !== undefined
+          ? getNameFromPath(childDirectoryPath)
+          : fileName
+
+      const directoryModification = updateDirectoryFilePointers(
+        existingDirModification,
+        filePointerPath,
+        requestTimestamp,
+        // Only delete if file pointer is the file (don't delete directories)
+        filePointerPath === fileName && isDeletion
+      )
+
+      directoryModifications.set(directoryKey, directoryModification)
+    })
+
+    // Prepare Repo Modifications:
+
+    // We want to use the top-most directory from the directory paths as the
+    // file pointer path because it's the direct decendent from the root.
+    // This should be the last element in the directoryPaths.
+    // If there are no directories and therefore no top-most directory, then
+    // we use the file path as the file pointer path.
+    const topMostDirectoryPath = directoryPaths[directoryPaths.length - 1]
+    const filePointerPath =
+      topMostDirectoryPath !== undefined
+        ? getNameFromPath(topMostDirectoryPath)
+        : fileName
+
+    repoModification = {
+      ...updateDirectoryFilePointers(
+        repoModification,
+        filePointerPath,
+        requestTimestamp,
+        // Only delete if file pointer is the file (don't delete directories)
+        filePointerPath === fileName && isDeletion
+      ),
+      timestamp: requestTimestamp
+    }
+  })
+
+  // Prepare Directories Documents:
+
+  // Fetch existing documents to merge new document
+  const directoryKeys = Array.from(directoryModifications.keys())
+  const storeDirectoryDocuments: StoreDirectoryDocument[] = []
+  if (directoryKeys.length > 0) {
+    const directoryFetchResult = await dataStore.fetch({ keys: directoryKeys })
+
+    // Prepare directory documents
+    directoryFetchResult.rows.forEach(row => {
+      const directoryKey = row.key
+      const directoryModification = directoryModifications.get(directoryKey)
+
+      if (directoryModification !== undefined) {
+        if ('doc' in row) {
+          let existingDirectory: StoreDirectoryDocument
+
+          try {
+            existingDirectory = asStoreDirectoryDocument(row.doc)
+          } catch (err) {
+            throw makeApiClientError(
+              422,
+              `Unable to write files under '${directoryKey}'. ` +
+                `Existing document is not a directory.`
+            )
+          }
+
+          const directoryDocument: StoreDirectoryDocument = mergeDirectoryFilePointers(
+            existingDirectory,
+            directoryModification
+          )
+
+          // Update document
+          storeDirectoryDocuments.push(directoryDocument)
+        } else {
+          // Insert document
+          storeDirectoryDocuments.push({
+            ...directoryModification,
+            _id: directoryKey
+          })
+        }
+      }
+    })
+  }
+
+  // Prepare Repo Document:
+
+  const repoFetchResult = await dataStore.fetch({ keys: [repoKey] })
+  const storeRepoDocuments: StoreRootDocument[] = []
+
+  // Prepare repo (root) documents
+  repoFetchResult.rows.forEach(row => {
+    const repoKey = row.key
+
+    if ('doc' in row) {
+      let existingRepo: StoreRootDocument
+
+      try {
+        existingRepo = asStoreRootDocument(row.doc)
+      } catch (err) {
+        throw makeApiClientError(
+          422,
+          `Unable to write files under '${repoKey}'. ` +
+            `Document is not a repo.`
+        )
+      }
+
+      const repoDocument: StoreRootDocument = mergeDirectoryFilePointers(
+        existingRepo,
+        repoModification
+      )
+
+      storeRepoDocuments.push(repoDocument)
+    } else {
+      // If no existing StoreRootDocument, then we should throw a client error
+      throw makeApiClientError(
+        422,
+        `Unable to write files under '${repoKey}'. ` +
+          `Document does not exist.`
+      )
+    }
+  })
+
+  // Writes:
+
+  // Write Files and Directories
+  const fileAndDirResults = await dataStore.bulk({
+    docs: [...storeFileDocuments, ...storeDirectoryDocuments]
+  })
+  checkResultsForErrors(fileAndDirResults)
+
+  // Write Repos
+  const repoResults = await dataStore.bulk({
+    docs: storeRepoDocuments
+  })
+  checkResultsForErrors(repoResults)
+}
+
+// This checks for conflicts and errors in the datastore write results
+const checkResultsForErrors = (results: DocumentBulkResponse[]): void =>
+  results.forEach(result => {
+    if (result.error !== '' && result.error !== undefined) {
+      if (result.error === 'conflict') {
+        // For conflict errors, throw specific error message
+        throw new Error(result.error)
+      } else {
+        const reason = result.reason
+        // For all other errors, throw because it's unexpected
+        throw new Error(
+          'Unexpected database error' +
+            (reason !== '' && reason !== undefined ? ': ' + reason : '')
+        )
+      }
+    }
+  })
+
+// ---------------------------------------------------------------------
+// GET /files
+// ---------------------------------------------------------------------
 
 filesRouter.get('/files', async (req, res, next) => {
   const paths: DocumentRequest = JSON.parse(req.query.paths)
@@ -37,9 +388,4 @@ filesRouter.get('/files', async (req, res, next) => {
     data: contents
   }
   res.status(200).json(result)
-})
-
-// Get wallet transactions based on type of wallet
-filesRouter.post('/files', async (req, res, next) => {
-  res.status(500).send('TODO')
 })

--- a/src/routes/root.ts
+++ b/src/routes/root.ts
@@ -1,7 +1,7 @@
 import { asNumber, asObject, asOptional, asString } from 'cleaners'
 import Router from 'express-promise-router'
 import { dataStore } from '../db'
-import { ApiErrorResponse, ApiResponse, StoreRoot } from '../types'
+import { ApiErrorResponse, ApiResponse, StoreRootDocument } from '../types'
 
 type RootPutBody = ReturnType<typeof asRootPutBody>
 
@@ -51,8 +51,9 @@ rootRouter.put('/', async (req, res, next) => {
 
   // Create new repo
   const timestamp = Date.now()
-  const repo: StoreRoot = {
-    files: {},
+  const repo: StoreRootDocument = {
+    paths: {},
+    deleted: {},
     timestamp,
     lastGitHash: body.lastGitHash,
     lastGitTime: body.lastGitTime,

--- a/src/routes/root.ts
+++ b/src/routes/root.ts
@@ -1,5 +1,6 @@
 import { asNumber, asObject, asOptional, asString } from 'cleaners'
 import Router from 'express-promise-router'
+
 import { dataStore } from '../db'
 import { ApiErrorResponse, ApiResponse, StoreRootDocument } from '../types'
 
@@ -10,7 +11,7 @@ interface RootPutResponseData {
 }
 
 const asRootPutBody = asObject({
-  repoid: asString,
+  repoId: asString,
   lastGitHash: asOptional(asString),
   lastGitTime: asOptional(asNumber)
 })
@@ -31,7 +32,7 @@ rootRouter.put('/', async (req, res, next) => {
     return res.status(400).json(response)
   }
 
-  const path: string = `${body.repoid}:/`
+  const path: string = `${body.repoId}:/`
 
   // Return HTTP 409 if repo already exists
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,31 @@
+import { asMap, asNumber, asObject, asOptional, asString } from 'cleaners'
 import * as Nano from 'nano'
 
-export interface StoreRoot extends Nano.MaybeDocument {
-  files: StoreFileMap
+// Is there a better way to make optional properties for this type?
+const asNanoMaybeDocument = asObject<Nano.MaybeDocument>({
+  _id: asOptional(asString),
+  _rev: asOptional(asString)
+})
+
+export type StoreFileMap = ReturnType<typeof asStoreFileMap>
+export const asStoreFileMap = asMap(asNumber)
+
+// Directory
+
+export type StoreDirectory = ReturnType<typeof asStoreDirectory>
+export type StoreDirectoryDocument = ReturnType<typeof asStoreDirectoryDocument>
+export const asStoreDirectory = asObject({
+  deleted: asStoreFileMap,
+  paths: asStoreFileMap
+})
+export const asStoreDirectoryDocument = asObject({
+  ...asNanoMaybeDocument.shape,
+  ...asStoreDirectory.shape
+})
+
+// Root
+
+export interface StoreRoot extends StoreDirectory {
   timestamp: number
   lastGitHash?: string
   lastGitTime?: number
@@ -9,10 +33,32 @@ export interface StoreRoot extends Nano.MaybeDocument {
   sizeLastCreated: number
   maxSize: number
 }
+export type StoreRootDocument = ReturnType<typeof asStoreRootDocument>
+export const asStoreRoot = asObject<StoreRoot>({
+  ...asStoreDirectory.shape,
+  timestamp: asNumber,
+  lastGitHash: asOptional(asString),
+  lastGitTime: asOptional(asNumber),
+  size: asNumber,
+  sizeLastCreated: asNumber,
+  maxSize: asNumber
+})
+export const asStoreRootDocument = asObject({
+  ...asNanoMaybeDocument.shape,
+  ...asStoreRoot.shape
+})
 
-export interface StoreFileMap {
-  [path: string]: number | null
-}
+// File
+
+export type StoreFile = ReturnType<typeof asStoreFile>
+export type StoreFileDocument = ReturnType<typeof asStoreFileDocument>
+export const asStoreFile = asObject({
+  text: asString
+})
+export const asStoreFileDocument = asObject({
+  ...asNanoMaybeDocument.shape,
+  ...asStoreFile.shape
+})
 
 export interface DocumentRequest {
   [Key: string]: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,9 @@ export interface ApiErrorResponse {
   success: false
   message: string
 }
+
+export type ApiClientError = ReturnType<typeof asApiClientError>
+export const asApiClientError = asObject({
+  status: asNumber,
+  message: asString
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,82 @@
+import { ApiClientError, StoreDirectory } from './types'
+
+export const makeApiClientError = (
+  status: number,
+  message: string
+): ApiClientError => {
+  return {
+    status,
+    message
+  }
+}
+
+export const getNameFromPath = (path: string): string => {
+  const pathParts = path.split('/')
+  return '/' + pathParts[pathParts.length - 1]
+}
+
+/**
+ * Returns an array of paths for each ancestory directory of a given
+ * file path starting with immediate parent directory to the top-most
+ * directory (which is the directory below the root/repo directory).
+ *
+ * Example: '/dir1/dir2/file.txt' -> ['/dir1/dir2/', '/dir1']
+ *
+ * @param path full path to a file
+ */
+export const getParentPathsOfPath = (path: string): string[] => {
+  const pathsSet = new Set<string>()
+  const parts = path.replace(/^\/+|\/+$/g, '').split('/')
+
+  for (let i = parts.length - 1; i > 0; --i) {
+    pathsSet.add('/' + parts.slice(0, i).join('/'))
+  }
+
+  return Array.from(pathsSet)
+}
+
+export const mergeDirectoryFilePointers = <T extends StoreDirectory>(
+  leftDir: T,
+  rightDir: StoreDirectory
+): T => {
+  const deleted = { ...leftDir.deleted, ...rightDir.deleted }
+  const paths = { ...leftDir.paths, ...rightDir.paths }
+
+  // In order to successfully merge changes into document, we must remove
+  // keys present in deleted that have moved to paths, or visa versa.
+  Object.keys(rightDir.deleted).forEach(path => {
+    delete paths[path]
+  })
+  Object.keys(rightDir.paths).forEach(path => {
+    delete deleted[path]
+  })
+
+  return {
+    ...leftDir,
+    ...rightDir,
+    deleted,
+    paths
+  }
+}
+
+export const updateDirectoryFilePointers = (
+  directory: StoreDirectory | undefined,
+  path: string,
+  timestamp: number,
+  isDeletion: boolean
+): StoreDirectory => {
+  const directoryMutations = {
+    paths: isDeletion ? {} : { [path]: timestamp },
+    deleted: isDeletion ? { [path]: timestamp } : {}
+  }
+  return {
+    paths: {
+      ...directory?.paths,
+      ...directoryMutations.paths
+    },
+    deleted: {
+      ...directory?.deleted,
+      ...directoryMutations.deleted
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,11 +884,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/caseless@*":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
-  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
-
 "@types/chai@^4.2.9":
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.9.tgz#194332625ed2ae914aef00b8d5ca3b77e7924cc6"
@@ -983,16 +978,6 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/request@^2.48.4":
-  version "2.48.5"
-  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
-  integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
-  dependencies:
-    "@types/caseless" "*"
-    "@types/node" "*"
-    "@types/tough-cookie" "*"
-    form-data "^2.5.0"
-
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
@@ -1000,11 +985,6 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
-
-"@types/tough-cookie@*":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
-  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@typescript-eslint/eslint-plugin@>=2.0.0":
   version "2.21.0"
@@ -1345,6 +1325,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
@@ -1555,11 +1542,6 @@ browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
   integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
-
-browser-request@~0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
-  integrity sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=
 
 browser-stdout@1.3.1:
   version "1.3.1"
@@ -1976,15 +1958,6 @@ clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
-cloudant-follow@^0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/cloudant-follow/-/cloudant-follow-0.18.2.tgz#35dd7b29c5b9c58423d50691f848a990fbe2c88f"
-  integrity sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==
-  dependencies:
-    browser-request "~0.3.0"
-    debug "^4.0.1"
-    request "^2.88.0"
 
 coa@^2.0.2:
   version "2.0.2"
@@ -2880,11 +2853,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-errs@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/errs/-/errs-0.3.2.tgz#798099b2dbd37ca2bc749e538a7c1307d0b50499"
-  integrity sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=
-
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
@@ -3533,6 +3501,11 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3547,15 +3520,6 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
-
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -5174,16 +5138,13 @@ nan@^2.12.1, nan@^2.14.0, nan@^2.2.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nano@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/nano/-/nano-8.2.2.tgz#4fdd48965cece51892cf41e78d433d1b772e6e40"
-  integrity sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==
+nano@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/nano/-/nano-9.0.1.tgz#69b93b461b905b8545bda8ec2cc2638c539568d5"
+  integrity sha512-RJ+xMWjVKb/Y2A3YDTC5hg+mvktcRl8XDRMLTa+i3wPaqb02BTEWdPHcDDqKqGnqs0cIwFu5vuwzvnrsr/pW+A==
   dependencies:
-    "@types/request" "^2.48.4"
-    cloudant-follow "^0.18.2"
-    debug "^4.1.1"
-    errs "^0.3.2"
-    request "^2.88.0"
+    axios "^0.21.0"
+    qs "^6.9.4"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6423,6 +6384,11 @@ qs@6.7.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
+qs@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
* Implements POST /files endpoint route handler to add/update files and
directories
* Validates IO using cleaners (i.e. request body, dataStore reads)
* Runs `filesUpdateRoutine` and retries on rev mismatch errors
* Add type information to the exported dataStore object
* Additional and updated "Store" types
  * Uses cleaners for all store types
  * Adds StoreDirectory and StoreDirectoryDocument
  * Adds StoreFile and StoreFileDocument
  * Updates StoreRoot to extend StoreDirectory (replace `files` property
with `paths` and `deleted`)
  * Adds StoreRootDocument to extend the Nano.MaybeDocument type
  * Update PUT root endpoint to be compatible with the StoreRoot changes