### PR TITLE
Get Files Endpoint

### DIFF
--- a/src/api/getFiles.ts
+++ b/src/api/getFiles.ts
@@ -1,0 +1,170 @@
+import { asMaybe } from 'cleaners'
+
+import { config } from '../config'
+import { dataStore } from '../db'
+import {
+  asStoreDirectoryDocument,
+  asStoreFile,
+  asStoreFileDocument,
+  asStoreRepoDocument,
+  StoreDirectoryDocument,
+  StoreFile,
+  StoreFileTimestampMap
+} from '../types'
+import {
+  getNameFromPath,
+  getParentPathsOfPath,
+  makeApiClientError
+} from '../utils'
+
+const { maxPageSize } = config
+
+export interface GetFilesStoreFileMap {
+  [path: string]: StoreFileWithTimestamp | StoreDirectoryPathWithTimestamp
+}
+
+export interface StoreFileWithTimestamp extends StoreFile {
+  timestamp: number
+}
+
+export interface StoreDirectoryPathWithTimestamp {
+  paths: StoreFileTimestampMap
+  timestamp: number
+}
+
+export async function fetchGetFilesStoreFileMap(
+  repoId: string,
+  requestPaths: StoreFileTimestampMap,
+  ignoreTimestamps: boolean
+): Promise<GetFilesStoreFileMap> {
+  const paths = Object.keys(requestPaths)
+
+  // Use max page size config to limit the paths processed
+  if (paths.length > maxPageSize) {
+    throw makeApiClientError(
+      422,
+      `Too many paths. maxPageSize is ${maxPageSize}`
+    )
+  }
+
+  interface ChildKeyToParentKeyMap {
+    [childKey: string]: string
+  }
+
+  const childKeyToParentKeyMap = paths.reduce(
+    (acc: ChildKeyToParentKeyMap, documentPath) => {
+      const documentKey = `${repoId}:${documentPath}`
+      const parentPaths = getParentPathsOfPath(documentPath)
+
+      // Document is is a repo; it's parent is itself
+      if (documentPath === '/') {
+        return Object.assign(acc, { [documentKey]: documentKey })
+      }
+
+      const parentPath = parentPaths.length > 0 ? parentPaths[0] : '/'
+      const parentKey = `${repoId}:${parentPath}`
+
+      return Object.assign(acc, { [documentKey]: parentKey })
+    },
+    {}
+  )
+
+  const childKeys = Object.keys(childKeyToParentKeyMap)
+  const parentKeys = Array.from(new Set(Object.values(childKeyToParentKeyMap)))
+
+  interface StoreDirectoryDocumentMap {
+    [documentKey: string]: StoreDirectoryDocument
+  }
+
+  const [parentDocumentResult, childDocumentResult] = await Promise.all([
+    dataStore.fetch({ keys: parentKeys }),
+    dataStore.fetch({ keys: childKeys })
+  ])
+
+  const parentDocumentMap = parentDocumentResult.rows.reduce(
+    (map: StoreDirectoryDocumentMap, row) => {
+      if (row.error === 'not_found') {
+        throw makeApiClientError(404, `Path '${row.key}' not found.`)
+      }
+
+      if (!('doc' in row)) throw new Error(row.error)
+
+      const doc = asMaybe(asStoreDirectoryDocument)(row.doc)
+
+      if (doc == null) {
+        throw new Error(`File '${row.key}' is not a directory.`)
+      }
+
+      return Object.assign(map, { [row.key]: doc })
+    },
+    {}
+  )
+
+  const responsePaths = childDocumentResult.rows.reduce(
+    (map: GetFilesStoreFileMap, row) => {
+      if (row.error === 'not_found') {
+        throw makeApiClientError(404, `Path '${row.key}' not found.`)
+      }
+
+      if (!('doc' in row)) throw new Error(row.error)
+
+      const documentKey = row.key
+      const documentPath = documentKey.split(':')[1]
+      const documentFileName = getNameFromPath(documentPath)
+
+      const parentDocumentKey = childKeyToParentKeyMap[documentKey]
+      const parentDocument = parentDocumentMap[parentDocumentKey]
+
+      const sentTimestamp = requestPaths[documentPath]
+
+      const fileDocument = asMaybe(asStoreFileDocument)(row.doc)
+      const repoDocument = asMaybe(asStoreRepoDocument)(row.doc)
+      const directoryDocument = asMaybe(asStoreDirectoryDocument)(row.doc)
+      const directoryLikeDocument = repoDocument ?? directoryDocument
+
+      // Because the repo's timestamp is included in the repo document
+      // we have to get the timestamp from the repo document
+      const timestamp =
+        repoDocument == null
+          ? parentDocument.paths[documentFileName]
+          : repoDocument.timestamp
+
+      if (!ignoreTimestamps && timestamp <= sentTimestamp) {
+        return map
+      }
+
+      // Handle file document
+      if (fileDocument != null) {
+        return Object.assign(map, {
+          [documentPath]: { ...asStoreFile(fileDocument), timestamp }
+        })
+      }
+
+      // Handle directory like document (repo or directory)
+      if (directoryLikeDocument != null && ignoreTimestamps === true) {
+        return Object.assign(map, {
+          [documentPath]: { paths: directoryLikeDocument.paths, timestamp }
+        })
+      }
+      if (directoryLikeDocument != null) {
+        // Remove files after timestamp check
+        const paths = Object.entries(directoryLikeDocument.paths).reduce(
+          (paths: StoreFileTimestampMap, [fileName, fileTimestamp]) =>
+            fileTimestamp > sentTimestamp
+              ? { ...paths, [fileName]: fileTimestamp }
+              : paths,
+          {}
+        )
+
+        return Object.assign(map, {
+          [documentPath]: { paths, timestamp }
+        })
+      }
+
+      throw new Error(`File '${row.key}' is not a file or directory.`)
+    },
+    {}
+  )
+
+  return responsePaths
+}

--- a/src/routes/getFiles.ts
+++ b/src/routes/getFiles.ts
@@ -1,0 +1,51 @@
+import { asBoolean, asMap, asNumber, asObject, asOptional } from 'cleaners'
+import Router from 'express-promise-router'
+
+import {
+  fetchGetFilesStoreFileMap,
+  GetFilesStoreFileMap
+} from '../api/getFiles'
+import { asNonEmptyString } from '../types'
+import { makeApiClientError, makeApiResponse } from '../utils'
+
+type GetFilesBody = ReturnType<typeof asGetFilesBody>
+const asGetFilesBody = asObject({
+  repoId: asNonEmptyString,
+  ignoreTimestamps: asOptional(asBoolean),
+  paths: asMap(asNumber)
+})
+
+interface GetFilesResponseData {
+  total: number
+  paths: GetFilesStoreFileMap
+}
+
+export const getFilesRouter = Router()
+
+getFilesRouter.post('/getFiles', async (req, res) => {
+  let body: GetFilesBody
+
+  // Validate request body
+  try {
+    body = asGetFilesBody(req.body)
+  } catch (err) {
+    throw makeApiClientError(400, err.message)
+  }
+
+  const { repoId, paths, ignoreTimestamps = false } = body
+
+  const getFilesStoreFileMap = await fetchGetFilesStoreFileMap(
+    repoId,
+    paths,
+    ignoreTimestamps
+  )
+
+  // Response:
+
+  res.status(200).json(
+    makeApiResponse<GetFilesResponseData>({
+      total: Object.keys(getFilesStoreFileMap).length,
+      paths: getFilesStoreFileMap
+    })
+  )
+})

--- a/src/v3Router.ts
+++ b/src/v3Router.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import { configRouter } from './routes/config'
+import { getFilesRouter } from './routes/getFiles'
 import { getUpdatesRouter } from './routes/getUpdates'
 import { repoRouter } from './routes/repo'
 import { updateFilesRouter } from './routes/updateFiles'
@@ -8,6 +9,7 @@ import { updateFilesRouter } from './routes/updateFiles'
 export const v3Router = Router()
 
 v3Router.use(configRouter)
+v3Router.use(getFilesRouter)
 v3Router.use(getUpdatesRouter)
 v3Router.use(repoRouter)
 v3Router.use(updateFilesRouter)

--- a/test/getFiles.test.ts
+++ b/test/getFiles.test.ts
@@ -1,0 +1,383 @@
+import { expect } from 'chai'
+import { it } from 'mocha'
+import supertest from 'supertest'
+
+import { app } from '../src/server'
+import { apiSuite } from './suites'
+import { delay, isSuccessfulResponse } from './utils'
+
+apiSuite('/api/v3/getFiles', () => {
+  const agent = supertest.agent(app)
+
+  const repoId = 'test'
+  const otherRepoId = 'other'
+  let repoTimestamp: number = 0
+  let oldestTs: number = 0
+  let latestTs: number = 0
+
+  const CONTENT = {
+    file1: { text: '/file1 content' },
+    file2: { text: '/file2 content' },
+    deletedFile: { text: '/deletedFile content' },
+    dirFile1: { text: '/dir/file1 content' },
+    dirFile2: { text: '/dir/file2 content' },
+    dirDeletedFile: { text: '/dir/deletedFil contente' }
+  } as const
+
+  // Fixtures:
+
+  before(async () => {
+    // Create test repo
+    let res = await agent
+      .put('/api/v3/repo')
+      .send({ repoId })
+      .expect(isSuccessfulResponse)
+    expect(res.body.data.timestamp).to.be.a('number')
+
+    repoTimestamp = res.body.data.timestamp
+
+    // Create test files/dirs (first files)
+    res = await agent
+      .post('/api/v3/updateFiles')
+      .send({
+        repoId,
+        timestamp: repoTimestamp,
+        paths: {
+          '/file1': CONTENT.file1,
+          '/deletedFile': CONTENT.deletedFile,
+          '/dir/file1': CONTENT.dirFile1,
+          '/dirDeletedFile': CONTENT.dirDeletedFile
+        }
+      })
+      .expect(isSuccessfulResponse)
+
+    oldestTs = repoTimestamp = res.body.data.timestamp
+
+    // Delete files
+    res = await agent
+      .post('/api/v3/updateFiles')
+      .send({
+        repoId,
+        timestamp: repoTimestamp,
+        paths: {
+          '/deletedFile': null,
+          '/dirDeletedFile': null
+        }
+      })
+      .expect(isSuccessfulResponse)
+
+    repoTimestamp = res.body.data.timestamp
+
+    await delay(10)
+
+    // Create test files/dir (second files)
+    res = await agent
+      .post('/api/v3/updateFiles')
+      .send({
+        repoId,
+        timestamp: repoTimestamp,
+        paths: {
+          '/file2': CONTENT.file2,
+          '/dir/file2': CONTENT.dirFile2
+        }
+      })
+      .expect(isSuccessfulResponse)
+
+    latestTs = repoTimestamp = res.body.data.timestamp
+
+    // Other repo control (should not be returned)
+    res = await agent
+      .put('/api/v3/repo')
+      .send({ repoId: otherRepoId })
+      .expect(isSuccessfulResponse)
+    res = await agent
+      .post('/api/v3/updateFiles')
+      .send({
+        repoId: otherRepoId,
+        timestamp: res.body.data.timestamp,
+        paths: {
+          '/file1.ignore': CONTENT.file1,
+          '/deletedFile.ignore': CONTENT.deletedFile,
+          '/dir/file1.ignore': CONTENT.dirFile1,
+          '/dirDeletedFile.ignore': CONTENT.dirDeletedFile
+        }
+      })
+      .expect(isSuccessfulResponse)
+    res = await agent
+      .post('/api/v3/updateFiles')
+      .send({
+        repoId: otherRepoId,
+        timestamp: res.body.data.timestamp,
+        paths: {
+          '/deletedFile.ignore': null,
+          '/dirDeletedFile.ignore': null
+        }
+      })
+      .expect(isSuccessfulResponse)
+  })
+
+  // Tests:
+
+  // Files
+  it('Can get files ignoring timestamp', async () => {
+    const paths = {
+      '/file1': 0,
+      '/file2': 0,
+      '/dir/file1': 0,
+      '/dir/file2': 0
+    }
+
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: true,
+        paths
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: Object.keys(paths).length,
+          paths: {
+            '/file1': { ...CONTENT.file1, timestamp: oldestTs },
+            '/file2': { ...CONTENT.file2, timestamp: latestTs },
+            '/dir/file1': {
+              ...CONTENT.dirFile1,
+              timestamp: oldestTs
+            },
+            '/dir/file2': {
+              ...CONTENT.dirFile2,
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+  })
+  it('Can get files with timestamp', async () => {
+    // Should return no file because same timestamp
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/file1': oldestTs
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 0,
+          paths: {}
+        })
+      })
+    // Should return single file because timestamp is decremented
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/file1': oldestTs - 1
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/file1': { ...CONTENT.file1, timestamp: oldestTs }
+          }
+        })
+      })
+  })
+
+  // Directories
+  it('Can get directories ignoring timestamp', async () => {
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: true,
+        paths: {
+          '/dir': 0
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/dir': {
+              paths: {
+                file1: oldestTs,
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+  })
+  it('Can get directories with timestamp', async () => {
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/dir': 0
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/dir': {
+              paths: {
+                file1: oldestTs,
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/dir': oldestTs
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/dir': {
+              paths: {
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/dir': latestTs
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 0,
+          paths: {}
+        })
+      })
+  })
+
+  // Repo
+  it('Can get repo ignoring timestamp', async () => {
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: true,
+        paths: {
+          '/': 0
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/': {
+              paths: {
+                dir: latestTs,
+                file1: oldestTs,
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+  })
+  it('Can get repo with timestamp', async () => {
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/': 0
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/': {
+              paths: {
+                dir: latestTs,
+                file1: oldestTs,
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/': oldestTs
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 1,
+          paths: {
+            '/': {
+              paths: {
+                dir: latestTs,
+                file2: latestTs
+              },
+              timestamp: latestTs
+            }
+          }
+        })
+      })
+    await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: false,
+        paths: {
+          '/': latestTs
+        }
+      })
+      .expect(isSuccessfulResponse)
+      .expect(res => {
+        expect(res.body.data).deep.equals({
+          total: 0,
+          paths: {}
+        })
+      })
+  })
+})


### PR DESCRIPTION
Adds new route for getting files, `POST /get-files`, as per spec: https://docs.google.com/document/d/1mfsmx3fZQMZ0KZELmP1lzB3cAbm0foBdJbzmyEjZR5A/edit#heading=h.xeptq1gsy60b

Includes route filename and endpoint changes to reflect updates to the spec.