### PR TITLE
Sam/v2 post store semantics fix

### DIFF
--- a/src/api/getUpdates.ts
+++ b/src/api/getUpdates.ts
@@ -75,6 +75,11 @@ export async function getDirectoryUpdates(
     deleted: {}
   }
 
+  // For repo keys, trim the trailing slash; dirs don't have trailing slashes
+  if (dirKey[dirKey.length - 1] === '/') {
+    dirKey = dirKey.substr(0, dirKey.length - 1)
+  }
+
   const pathsKeys = Object.keys(dir.paths).map(path => [dirKey, path].join('/'))
   const deletedKeys = Object.keys(dir.deleted).map(path =>
     [dirKey, path].join('/')

--- a/src/api/migrations.ts
+++ b/src/api/migrations.ts
@@ -124,7 +124,12 @@ export const migrateRepo = async (repoId: string): Promise<void> => {
           })
         } catch (err) {
           // Silence conflict errors
-          if (err.error !== 'conflict') {
+          if (err.error === 'conflict') {
+            console.log(
+              `Conflict migrating repo ID ${repoId}. ` +
+                `Migration was already completed by another process.`
+            )
+          } else {
             throw err
           }
         }

--- a/src/api/updateFiles.ts
+++ b/src/api/updateFiles.ts
@@ -21,6 +21,7 @@ import {
   validateModification,
   withRetries
 } from '../utils'
+import { getRepoDocument } from './repo'
 
 type RepoModification = Pick<
   StoreRepoDocument,
@@ -28,17 +29,9 @@ type RepoModification = Pick<
 >
 
 export async function validateRepoTimestamp(repoId, timestamp): Promise<void> {
-  const repoKey = `${repoId}:/`
+  const repoDoc = await getRepoDocument(repoId)
 
   // Validate request body timestamp
-  let repoDoc: StoreRepoDocument
-  try {
-    const repoQuery = await dataStore.get(repoKey)
-    repoDoc = asStoreRepoDocument(repoQuery)
-  } catch (err) {
-    throw new Error(`Failed to validate repo: ${err.message}`)
-  }
-
   if (repoDoc.timestamp !== timestamp) {
     throw makeApiClientError(422, `Failed due to out-of-date timestamp`)
   }

--- a/src/routes/getUpdates.ts
+++ b/src/routes/getUpdates.ts
@@ -39,7 +39,7 @@ getUpdatesRouter.post('/getUpdates', async (req, res) => {
 
   if (clientTimestamp < repoDocument.timestamp) {
     const { paths, deleted } = await getDirectoryUpdates(
-      repoKey.slice(0, -1),
+      repoKey,
       repoDocument,
       clientTimestamp
     )

--- a/src/routes/getUpdates.ts
+++ b/src/routes/getUpdates.ts
@@ -2,12 +2,8 @@ import { asNumber, asObject, asString } from 'cleaners'
 import Router from 'express-promise-router'
 
 import { getDirectoryUpdates } from '../api/getUpdates'
-import { dataStore } from '../db'
-import {
-  asStoreRepoDocument,
-  StoreFileTimestampMap,
-  StoreRepoDocument
-} from '../types'
+import { getRepoDocument } from '../api/repo'
+import { StoreFileTimestampMap } from '../types'
 import { makeApiClientError } from '../utils'
 
 export const getUpdatesRouter = Router()
@@ -34,20 +30,7 @@ getUpdatesRouter.post('/getUpdates', async (req, res) => {
 
   const { repoId, timestamp: clientTimestamp } = body
   const repoKey = `${repoId}:/`
-
-  let repoDocument: StoreRepoDocument
-  try {
-    const repoDocumentResult = await dataStore.get(repoKey)
-    repoDocument = asStoreRepoDocument(repoDocumentResult)
-  } catch (err) {
-    if (err.error === 'not_found') {
-      throw makeApiClientError(404, `Repo '${repoId}' not found`)
-    } else if (err instanceof TypeError) {
-      throw new Error(`'${repoKey}' is not a repo document`)
-    } else {
-      throw err
-    }
-  }
+  const repoDocument = await getRepoDocument(repoId)
 
   const responseData: GetUpdatesResponseData = {
     paths: {},


### PR DESCRIPTION
This fixes the issue noticed where the client was not persisting changes to its local directory. The cause of the issue was that a V2 client expects it's changes to be included in the `POST /api/v2/store/<repo>/<hash>` API response. Omission of the client's changes in the response caused the client to forgo those changes locally.

This PR includes the fix, modified tests, and some code changes made for clarity.