### PR TITLE
Sam/fix get updates response

### DIFF
--- a/src/routes/getUpdates.ts
+++ b/src/routes/getUpdates.ts
@@ -4,7 +4,7 @@ import Router from 'express-promise-router'
 import { getDirectoryUpdates } from '../api/getUpdates'
 import { getRepoDocument } from '../api/repo'
 import { asRepoId, StoreFileTimestampMap } from '../types'
-import { makeApiClientError } from '../util/utils'
+import { makeApiClientError, makeApiResponse } from '../util/utils'
 
 export const getUpdatesRouter = Router()
 
@@ -46,9 +46,7 @@ getUpdatesRouter.post('/getUpdates', async (req, res) => {
 
     responseData.paths = paths
     responseData.deleted = deleted
-
-    res.status(200).json(responseData)
-  } else {
-    res.status(200).json(responseData)
   }
+
+  res.status(200).json(makeApiResponse<GetUpdatesResponseData>(responseData))
 })

--- a/src/routes/getUpdates.ts
+++ b/src/routes/getUpdates.ts
@@ -15,6 +15,7 @@ const asGetUpdatesBody = asObject({
 })
 
 interface GetUpdatesResponseData {
+  timestamp: number
   paths: StoreFileTimestampMap
   deleted: StoreFileTimestampMap
 }
@@ -33,6 +34,7 @@ getUpdatesRouter.post('/getUpdates', async (req, res) => {
   const repoDocument = await getRepoDocument(repoId)
 
   const responseData: GetUpdatesResponseData = {
+    timestamp: repoDocument.timestamp,
     paths: {},
     deleted: {}
   }

--- a/test/getUpdates.test.ts
+++ b/test/getUpdates.test.ts
@@ -141,15 +141,18 @@ apiSuite('/api/v3/getUpdates', () => {
       .expect(isSuccessfulResponse)
       .expect(res => {
         expect(res.body).deep.equals({
-          paths: {
-            '/file1': oldestTs,
-            '/dir/file1': oldestTs,
-            '/dir/file2': latestTs,
-            '/file2': latestTs
-          },
-          deleted: {
-            '/deletedFile': deletionTs,
-            '/dirDeletedFile': deletionTs
+          success: true,
+          data: {
+            paths: {
+              '/file1': oldestTs,
+              '/dir/file1': oldestTs,
+              '/dir/file2': latestTs,
+              '/file2': latestTs
+            },
+            deleted: {
+              '/deletedFile': deletionTs,
+              '/dirDeletedFile': deletionTs
+            }
           }
         })
       })
@@ -162,13 +165,16 @@ apiSuite('/api/v3/getUpdates', () => {
       .expect(isSuccessfulResponse)
       .expect(res => {
         expect(res.body).deep.equals({
-          paths: {
-            '/dir/file2': latestTs,
-            '/file2': latestTs
-          },
-          deleted: {
-            '/deletedFile': deletionTs,
-            '/dirDeletedFile': deletionTs
+          success: true,
+          data: {
+            paths: {
+              '/dir/file2': latestTs,
+              '/file2': latestTs
+            },
+            deleted: {
+              '/deletedFile': deletionTs,
+              '/dirDeletedFile': deletionTs
+            }
           }
         })
       })
@@ -178,11 +184,14 @@ apiSuite('/api/v3/getUpdates', () => {
       .expect(isSuccessfulResponse)
       .expect(res => {
         expect(res.body).deep.equals({
-          paths: {
-            '/dir/file2': latestTs,
-            '/file2': latestTs
-          },
-          deleted: {}
+          success: true,
+          data: {
+            paths: {
+              '/dir/file2': latestTs,
+              '/file2': latestTs
+            },
+            deleted: {}
+          }
         })
       })
     await agent
@@ -191,8 +200,11 @@ apiSuite('/api/v3/getUpdates', () => {
       .expect(isSuccessfulResponse)
       .expect(res => {
         expect(res.body).deep.equals({
-          paths: {},
-          deleted: {}
+          success: true,
+          data: {
+            paths: {},
+            deleted: {}
+          }
         })
       })
   })

--- a/test/getUpdates.test.ts
+++ b/test/getUpdates.test.ts
@@ -140,20 +140,15 @@ apiSuite('/api/v3/getUpdates', () => {
       .send({ repoId, timestamp: 0 })
       .expect(isSuccessfulResponse)
       .expect(res => {
-        expect(res.body).deep.equals({
-          success: true,
-          data: {
-            paths: {
-              '/file1': oldestTs,
-              '/dir/file1': oldestTs,
-              '/dir/file2': latestTs,
-              '/file2': latestTs
-            },
-            deleted: {
-              '/deletedFile': deletionTs,
-              '/dirDeletedFile': deletionTs
-            }
-          }
+        expect(res.body.data.paths).deep.equals({
+          '/file1': oldestTs,
+          '/dir/file1': oldestTs,
+          '/dir/file2': latestTs,
+          '/file2': latestTs
+        })
+        expect(res.body.data.deleted).deep.equals({
+          '/deletedFile': deletionTs,
+          '/dirDeletedFile': deletionTs
         })
       })
   })
@@ -164,18 +159,13 @@ apiSuite('/api/v3/getUpdates', () => {
       .send({ repoId, timestamp: oldestTs })
       .expect(isSuccessfulResponse)
       .expect(res => {
-        expect(res.body).deep.equals({
-          success: true,
-          data: {
-            paths: {
-              '/dir/file2': latestTs,
-              '/file2': latestTs
-            },
-            deleted: {
-              '/deletedFile': deletionTs,
-              '/dirDeletedFile': deletionTs
-            }
-          }
+        expect(res.body.data.paths).deep.equals({
+          '/dir/file2': latestTs,
+          '/file2': latestTs
+        })
+        expect(res.body.data.deleted).deep.equals({
+          '/deletedFile': deletionTs,
+          '/dirDeletedFile': deletionTs
         })
       })
     await agent
@@ -183,29 +173,19 @@ apiSuite('/api/v3/getUpdates', () => {
       .send({ repoId, timestamp: deletionTs })
       .expect(isSuccessfulResponse)
       .expect(res => {
-        expect(res.body).deep.equals({
-          success: true,
-          data: {
-            paths: {
-              '/dir/file2': latestTs,
-              '/file2': latestTs
-            },
-            deleted: {}
-          }
+        expect(res.body.data.paths).deep.equals({
+          '/dir/file2': latestTs,
+          '/file2': latestTs
         })
+        expect(res.body.data.deleted).deep.equals({})
       })
     await agent
       .post('/api/v3/getUpdates')
       .send({ repoId, timestamp: latestTs })
       .expect(isSuccessfulResponse)
       .expect(res => {
-        expect(res.body).deep.equals({
-          success: true,
-          data: {
-            paths: {},
-            deleted: {}
-          }
-        })
+        expect(res.body.data.paths).deep.equals({})
+        expect(res.body.data.deleted).deep.equals({})
       })
   })
 })


### PR DESCRIPTION
`/api/v3/getUpdates` was missing the `"success"` and `"data"` fields. Added these for consistency.

Also, I suggest we add the repo's timestamp to the response for `getUpdates` for convenience.