### PR TITLE
Sam/conflict resolution improvement

### DIFF
--- a/src/api/getFiles.ts
+++ b/src/api/getFiles.ts
@@ -64,12 +64,10 @@ export const fetchGetFilesMap = (appState: AppState) => async (
   const parentDocumentMap = parentDocumentResults.reduce(
     (map: StoreDirectoryDocumentMap, result) => {
       if ('error' in result) {
-        if (result.error.error === 'not_found') {
+        if (result.error === 'not_found') {
           throw makeApiClientError(404, `Path '${result.key}' not found.`)
         }
-        throw new Error(
-          `Failed to get document: ${JSON.stringify(result.error)}`
-        )
+        throw result
       }
 
       const doc = asMaybe(asStoreDirectoryDocument)(result.doc)
@@ -86,12 +84,10 @@ export const fetchGetFilesMap = (appState: AppState) => async (
   const responsePaths = childDocumentResults.reduce(
     (map: GetFilesMap, result) => {
       if ('error' in result) {
-        if (result.error.error === 'not_found') {
+        if (result.error === 'not_found') {
           throw makeApiClientError(404, `Path '${result.key}' not found.`)
         }
-        throw new Error(
-          `Failed to get document: ${JSON.stringify(result.error)}`
-        )
+        throw result
       }
 
       const documentKey = result.key

--- a/src/api/getUpdates.ts
+++ b/src/api/getUpdates.ts
@@ -97,16 +97,18 @@ export const getDirectoryUpdates = (appState: AppState) => async (
     if (keys.length > 0) {
       const results = await getConflictFreeDocuments(appState)(keys)
 
-      for (const row of results) {
-        const documentKey = row.key
+      for (const result of results) {
+        const documentKey = result.key
         const documentPath = documentKey.split(':')[1]
         const documentName = getNameFromPath(documentPath)
         // The timestamp for the document from the indexing document
         const documentTimestamp = dir[prop][documentName]
 
-        if ('doc' in row) {
-          const fileDocument = asMaybe(asStoreFileDocument)(row.doc)
-          const directoryDocument = asMaybe(asStoreDirectoryDocument)(row.doc)
+        if ('doc' in result) {
+          const fileDocument = asMaybe(asStoreFileDocument)(result.doc)
+          const directoryDocument = asMaybe(asStoreDirectoryDocument)(
+            result.doc
+          )
 
           const mergeBaseTimestamp =
             fileDocument?.mergeBaseTimestamp ??
@@ -160,6 +162,10 @@ export const getDirectoryUpdates = (appState: AppState) => async (
             throw new Error(`Unexpected document for '${documentKey}'`)
           }
         } else {
+          if (result.error !== 'not_found') {
+            throw result
+          }
+
           rtn.isConsistent = false
         }
       }


### PR DESCRIPTION
This rewrite improves performance for the runtime conflict algorithm by first using the `_all_docs` CouchDB endpoint to query for documents and then only calling `_bulk_get` to retrieve document conflicts should they exist.