### PR TITLE
Sam/migration testing

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -11,6 +11,11 @@
   "maxTimestampHistoryAge": 2592000000,
   "maxPageSize": 100,
   "instanceCount": 16,
-  "migrationOriginServers": ["https://..."],
-  "migrationTmpDir": "/tmp/edge-sync-server/"
+  "migrationOriginServers": [
+    "https://git-uk.edge.app/repos/",
+    "https://git3.airbitz.co/repos/",
+    "https://git-eusa.edge.app/repos/"
+  ],
+  "migrationTmpDir": "/tmp/edge-sync-server/",
+  "testMigrationRepo": "000000000000000000000000000000000ed9e123"
 }

--- a/src/bin/background-migration/config.schema.ts
+++ b/src/bin/background-migration/config.schema.ts
@@ -1,5 +1,6 @@
 import { asArray, asNumber, asObject, asString } from 'cleaners'
 
+/* istanbul ignore next */
 export const asConfig = asObject({
   dataDir: asString,
   sshHosts: asArray(asString),

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -25,5 +25,6 @@ export const asConfig = asObject({
   // URL of the servers from which to migrate repos.
   migrationOriginServers: asArray(asString),
   // Temp directory to use for repo migrations
-  migrationTmpDir: asString
+  migrationTmpDir: asString,
+  testMigrationRepo: asString
 })

--- a/test/migrations.test.ts
+++ b/test/migrations.test.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai'
+import { it } from 'mocha'
+import supertest from 'supertest'
+
+import { AppState, makeServer } from '../src/server'
+import { GetFilesResponse, GetStoreResponse } from '../src/types'
+import { apiSuite } from './suites'
+import { isSuccessfulResponse } from './utils'
+
+apiSuite('Migrations', (appState: AppState) => {
+  const app = makeServer(appState)
+  const agent = supertest.agent(app)
+
+  const v2Hostnames = appState.config.migrationOriginServers.map(
+    url => new URL(url).hostname
+  )
+  const v2Agents = v2Hostnames.map(hostname =>
+    supertest.agent(`https://${hostname}`)
+  )
+
+  const repoId = appState.config.testMigrationRepo
+  let repoStoreContent: GetStoreResponse
+  const paths: { [path: string]: number } = {}
+
+  // Fixtures:
+
+  before(async () => {
+    // Get the repo/store data from one of the V2 servers
+    const responses = await Promise.all(
+      v2Agents.map(v2Agent => v2Agent.get(`/api/v2/store/${repoId}`))
+    )
+
+    const successfulResponse = responses.find(res => res.status === 200)
+
+    if (successfulResponse == null) {
+      throw new Error(
+        'Unable to find testMigrationRepo in any of the migrationOriginServers'
+      )
+    }
+
+    repoStoreContent = successfulResponse.body
+
+    Object.keys(repoStoreContent.changes).forEach(key => {
+      // Add leading forward-slash
+      paths[`/${key}`] = 0
+    })
+  })
+
+  // Tests:
+
+  it('GET /api/v3/getFiles passive migration', async () => {
+    const res = await agent
+      .post('/api/v3/getFiles')
+      .send({
+        repoId,
+        ignoreTimestamps: true,
+        paths
+      })
+      .expect(isSuccessfulResponse)
+
+    const data: GetFilesResponse = res.body.data
+
+    for (const path in data.paths) {
+      const fileData = data.paths[path]
+      // Remove leading forward-slash
+      const expectedFileContent = repoStoreContent.changes[path.substr(1)]
+
+      if (!('box' in fileData)) {
+        throw new Error(`Expected 'box' field in response data`)
+      }
+
+      expect(fileData.box).to.deep.equal(expectedFileContent)
+      expect(
+        fileData.timestamp != null,
+        `Expected 'timestamp' field in response data`
+      )
+      expect(
+        !isNaN(parseInt(fileData.timestamp)),
+        `Expected 'timestamp' field to be a timestamp in response data`
+      )
+    }
+  })
+})

--- a/test/v2/migrations.test.ts
+++ b/test/v2/migrations.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai'
+import { it } from 'mocha'
+import supertest from 'supertest'
+
+import { AppState, makeServer } from '../../src/server'
+import { GetStoreResponse } from '../../src/types'
+import { apiSuite } from '../suites'
+import { isSuccessfulResponse } from '../utils'
+
+apiSuite('Migrations', (appState: AppState) => {
+  const app = makeServer(appState)
+  const agent = supertest.agent(app)
+
+  const v2Hostnames = appState.config.migrationOriginServers.map(
+    url => new URL(url).hostname
+  )
+  const v2Agents = v2Hostnames.map(hostname =>
+    supertest.agent(`https://${hostname}`)
+  )
+
+  const repoId = appState.config.testMigrationRepo
+  let repoStoreContent: GetStoreResponse
+
+  // Fixtures:
+
+  before(async () => {
+    // Get the repo/store data from one of the V2 servers
+    const responses = await Promise.all(
+      v2Agents.map(v2Agent => v2Agent.get(`/api/v2/store/${repoId}`))
+    )
+
+    const successfulResponse = responses.find(res => res.status === 200)
+
+    if (successfulResponse == null) {
+      throw new Error(
+        'Unable to find testMigrationRepo in any of the migrationOriginServers'
+      )
+    }
+
+    repoStoreContent = successfulResponse.body
+  })
+
+  // Tests:
+
+  it('GET /api/v2/store passive migration', async () => {
+    const res = await agent
+      .get(`/api/v2/store/${repoId}`)
+      .expect(isSuccessfulResponse)
+
+    expect(res.body.changes).to.deep.equal(repoStoreContent.changes)
+    expect(res.body.hash != null, 'Missing hash field in response')
+    expect(
+      !isNaN(parseInt(res.body.hash)),
+      'Hash field should be a timestamp value'
+    )
+  })
+})


### PR DESCRIPTION
Includes component tests for getStore (v2) and getFiles (v3). Unit tests were skipped because doing a component test gives us full coverage on all the unit functions. If there are more cases worth-while including besides "it can migrate a repo" test, then those could be added. But least we have coverage on our endpoints to avoid regression.