### PR TITLE
Improved stress test logging and performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "posttest": "nyc report --reporter=cobertura --reporter=html",
     "test.post-report": "open ./coverage/index.html ./coverage/mochawesome.html",
     "test.report": "yarn test.with-report && yarn test.post-report",
-    "test.stress": "node -r sucrase/register src/bin/stress-test/index.ts ",
+    "test.stress": "node -r sucrase/register src/bin/stress-test/index.ts",
+    "test.stress.console": "LOG_LEVEL=trace node -r sucrase/register src/bin/stress-test/index.ts | node -r sucrase/register src/bin/stress-test/console.ts",
     "test.stress.continuous": "node -r sucrase/register src/bin/continuous-stress-test/index.ts | pino-pretty",
     "test.watch": "yarn test --watch --watch-files 'src/**/*, test/**/*'",
     "test.with-report": "nyc yarn test --reporter mocha-multi-reporters --reporter-options configFile=./mocha-config.json"

--- a/pm2/continuous-stress-test.json
+++ b/pm2/continuous-stress-test.json
@@ -4,7 +4,8 @@
       "name": "continuous-stress-test",
       "script": "lib/bin/continuous-stress-test/index.js",
       "error_file": "logs/continuous-stress-test/error.log",
-      "out_file": "logs/continuous-stress-test/out.log"
+      "out_file": "logs/continuous-stress-test/out.log",
+      "node_args": "--max-old-space-size=16384"
     }
   ]
 }

--- a/src/bin/stress-test/config.ts
+++ b/src/bin/stress-test/config.ts
@@ -1,8 +1,7 @@
-import { asArray, asBoolean, asNumber, asObject, asString } from 'cleaners'
+import { asArray, asNumber, asObject, asString } from 'cleaners'
 
 export type Config = ReturnType<typeof asConfig>
 export const asConfig = asObject({
-  verbose: asBoolean,
   // Servers
   clusters: asObject(asArray(asString)),
   // Sync Key
@@ -26,7 +25,6 @@ export const asConfig = asObject({
 })
 
 export const configSample: Config = {
-  verbose: false,
   clusters: {
     us: [
       'https://sync-us1.edge.app',

--- a/src/bin/stress-test/console.ts
+++ b/src/bin/stress-test/console.ts
@@ -1,0 +1,20 @@
+import pinoPretty from 'pino-pretty'
+import { createInterface } from 'readline'
+
+import { print, statusBarLine, statusBox } from './utils/printing'
+
+const pretty = pinoPretty({})
+
+const rl = createInterface({
+  input: process.stdin
+})
+
+rl.on('line', line => {
+  const log = JSON.parse(line)
+
+  if (log.msg === 'status') {
+    statusBox(log.status.join('\n' + statusBarLine() + '\n'))
+  } else {
+    print(pretty(log))
+  }
+})

--- a/src/bin/stress-test/utils/printing.ts
+++ b/src/bin/stress-test/utils/printing.ts
@@ -28,16 +28,12 @@ export const statusBarLine = (): string =>
 let statusText: string = ''
 
 export const statusBox = (text: string): void => {
-  if (process.env.VERBOSE !== '1') return
-
   const line = statusBarLine()
   logUpdate([line, text].join('\n'))
   statusText = text
 }
 
 export const print = (...args: any[]): void => {
-  if (process.env.VERBOSE !== '1') return
-
   args.forEach(arg => {
     const text =
       typeof arg === 'string'
@@ -47,18 +43,4 @@ export const print = (...args: any[]): void => {
     logUpdate.done()
   })
   statusBox(statusText)
-}
-
-export const printLog = (...args: any[]): void => {
-  if (process.env.VERBOSE !== '1') return
-
-  const convert = (val: any): string =>
-    typeof val !== 'string' ? JSON.stringify(val) : val
-  const log = args
-    .slice(1)
-    .reduce<string>(
-      (log, arg, i) => log + ' | ' + convert(arg),
-      convert(args[0]).padStart(16, '–').slice(0, 16)
-    )
-  print(log)
 }


### PR DESCRIPTION
The motivation is to improve logging performance and usefulness for continuously running stress tests. This PR should remove potential memory issues.

This changes the stress tests to continuously log "snapshots" about the running state of the stress tests rather than buffering the logs in an output object to be dumped when the stress tests finish. We now use pino for logging for simplification/performance and we add a "console" file that can format the log output into a nice looking view for development.