### PR TITLE
Change default migration configuration

### DIFF
--- a/config.migration.sample.json
+++ b/config.migration.sample.json
@@ -1,7 +1,11 @@
 {
-  "dataDir": "/tmp/data",
-  "sshHosts": ["user@hostname"],
-  "remoteReposDir": "/var/repos",
+  "dataDir": "../data/background-migration",
+  "sshHosts": [
+    "bitz@git-migration-uk.edge.app",
+    "bitz@git-migration-wusa.edge.app",
+    "bitz@git-migration-eusa.edge.app"
+  ],
+  "remoteReposDir": "/home/bitz/repos",
   "syncServer": "http://localhost:8000",
   "migrationEndpoint": "/api/v2/migrate/:syncKey",
   "concurrency": 10

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,9 +42,8 @@ export const asConfig = asObject({
   instanceCount: asOptional(asNumber, isDev ? 4 : undefined),
   migrationMaxBufferSize: asOptional(asNumber, MIGRATION_MAX_BUFFER_SIZE),
   migrationOriginServers: asOptional(asArray(asString), [
-    'https://git-uk.edge.app/repos/',
-    'https://git3.airbitz.co/repos/',
-    'https://git-eusa.edge.app/repos/'
+    'https://git-migration-uk.edge.app/repos/',
+    'https://git-migration-wusa.edge.app/repos/'
   ]),
   migrationTmpDir: asOptional(asString, '/tmp/app/edge-sync-server/'),
   testMigrationSyncKey: asOptional(


### PR DESCRIPTION
Use new git-migration-* domains.
Change config.migration.sample.json to more match production config.