### PR TITLE
Fix stack overflow in calculateLatestCheckpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# edge-sync-server
+
+## Unreleased
+
+- fixed: Fixed call-stack overflow bug when calculating latest checkpoint.

--- a/src/util/store/syncing.ts
+++ b/src/util/store/syncing.ts
@@ -171,9 +171,10 @@ const calculateLatestCheckpoint = (
     // Remove any previous document versions being overwritten.
     // If there exists versions that are lower or equal than the current
     // checkpoint version, then the max is the previous version.
-    const previousVersion = Math.max(
-      0,
-      ...document.versions.filter(version => version <= checkpoint.version)
+    const previousVersion = document.versions.reduce(
+      (max, version) =>
+        version <= checkpoint.version && version > max ? version : max,
+      0
     )
     // Add latest version and subtract previous version.
     return sum + document.versions[0] - previousVersion


### PR DESCRIPTION
Replace Math.max(...spread) with reduce to avoid exceeding the call stack when a document's versions array is very large.

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized algorithm change in checkpoint calculation plus a changelog entry; behavior should be equivalent but could affect sum/version math if the reduce logic is incorrect.
> 
> **Overview**
> Fixes a potential call-stack overflow in `calculateLatestCheckpoint` when processing documents with very large `versions` arrays.
> 
> Replaces the `Math.max(...spread)` computation of `previousVersion` with an iterative `reduce`, and adds a CHANGELOG entry documenting the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ddd7bcee937db59154f4704c60b1870f5aea74f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213598165081539